### PR TITLE
Forwarding information to backend systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Apache2.4 personnal configuration and website templates on Debian linux distribu
 
 - Debian linux distribution: ~9.1
 - apache: ~2.4.25
-  - ssl_module
+  - Modules: alias, deflate, dir, env, evasive, expires, filter, headers, http2, include, rewrite, unique_id, ssl_module, proxy_module, proxy_http_module / proxy_http2_module, remoteip_module
 - openssl: ~1.1.0f
 
 ## Configuration
@@ -34,6 +34,7 @@ When it starts, Apache2.4 includes the module configuration files (/etc/apache2/
 - zzz-mpm_event.conf: overrides the event worker MPM default configuration.
 - zzz-php7.x-fpm.conf: configure the local php-fpm using proxy.
 - zzz-proxy.conf: overrides the multi-protocol proxy/gateway server default configuration.
+-- zzz-remoteip.conf: overides remoteip configuration.
 - zzz-security.conf: overrides and adds more security configuration snippets for the server.
 - zzz-ssl.conf: SSL configuration.
 - zzz-status.conf: overrides the status and info modules configurations.
@@ -66,7 +67,7 @@ Module mod_http2 must be enable to provides HTTP/2 support in SSL.
 - app.tld: contains the name-based vhost configuration for a PHP application.
 - api.tld: contains the name-based vhost configuration for a mixed static website and PHP application.
 - redirect.tld: contains the configuration for a redirection.
-- reverseproxy.tld: configuration sample for a reverse proxy. proxy_module and proxy_http_module or proxy_http2_module are required.
+- reverseproxy.tld: configuration sample for a reverse proxy. **remoteip_module**, **proxy_module** and **proxy_http_module** or/and **proxy_http2_module** are required.
 - loader.conf: one file to rule them all.
 
 ### How to setup the site templates

--- a/src/conf-available/zzz-log.conf
+++ b/src/conf-available/zzz-log.conf
@@ -26,19 +26,20 @@
     # Use mod_remoteip instead.
     #
     LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
-    #LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
-    LogFormat "%h %l %u [%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t] \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
     LogFormat "%h %l %u %t \"%r\" %>s %O" common
     LogFormat "%{Referer}i -> %U" referer
     LogFormat "%{User-agent}i" agent
 
     # Extending the logs format
     ErrorLogFormat "[%{cu}t] [%-m:%-l] %-a %-L %M"
-    LogFormat "%h %l %u [%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t] \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" \"%{Content-Type}i\" %{remote}p %v %A %p %R \
-%{BALANCER_WORKER_ROUTE}e %X \"%{cookie}n\" %{UNIQUE_ID}e %{SSL_PROTOCOL}x %{SSL_CIPHER}x \
-%I %O %{ratio}n%% %D %{ModSecTimeIn}e %{ApplicationTime}e %{ModSecTimeOut}e \
-%{ModSecAnomalyScoreInPLs}e %{ModSecAnomalyScoreOutPLs}e \
-%{ModSecAnomalyScoreIn}e %{ModSecAnomalyScoreOut}e" extended
+    LogFormat "%h %l %u [%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t] \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" x_combined
+
+    # Log format for a backend server behind a reverse proxy
+    LogFormat "%a %l %u [%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t] \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" %D %{UNIQUE_ID}e %{X-PROXY-UNIQUE-ID}e" backend_combined
+
+    # Log format for a reverse proxy
+    LogFormat "%h %l %u [%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t] \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" %D %{UNIQUE_ID}e" proxy_combined
 
 </IfModule>
 
@@ -53,7 +54,7 @@
 # %b Bytes sent, excluding headers.
 # %{Referer}i The contents of Referer
 # %{User-Agent}i The contents of User-Agent
-# %{Content-Type}i The contents of Content-Type Request header
+# %{Content-Type}0 The contents of Content-Type Request header
 # %{remote}p Port number of the client.
 # %v Canonical host name of the server that handled the request.
 # %A IP address of the server that received the request.

--- a/src/conf-available/zzz-proxy.conf
+++ b/src/conf-available/zzz-proxy.conf
@@ -13,7 +13,9 @@
     # Affects only the connection to the backend. .
     ProxyTimeout 60
     <Proxy "*">
-        # Usually we use the local ip address
+        # Usually, for PHP-FPM, we only use the local ip address
         Require local
+        # Uncomment if reverse-proxy case
+        #Require ip <proxy-ip>
     </Proxy>
 </IfModule>

--- a/src/conf-available/zzz-remoteip.conf
+++ b/src/conf-available/zzz-remoteip.conf
@@ -1,0 +1,15 @@
+## -----------------------------------------------------
+## Apache 2.4
+## Remote IP configuration file.
+##
+## @context server config
+## @module remoteip_module
+## @author Olivier Jullien <https://github.com/ojullien>
+## -----------------------------------------------------
+
+<IfModule remoteip_module>
+    # Used for the log.
+    # If the request comes from <proxy-ip> then this server use "X-Forwarded-For" value to populate %a
+    RemoteIPHeader X-Forwarded-For
+    RemoteIPInternalProxy <proxy-ip>
+</IfModule>

--- a/src/sites-available/reverseproxy.tld/https.conf
+++ b/src/sites-available/reverseproxy.tld/https.conf
@@ -63,6 +63,12 @@ Define USER_SITE_DIR ${USER_DOMAIN_NAME}
     # Virtual Host configuration
     Include sites-available/${USER_SITE_DIR}/include/vhost.conf
 
+    # Forwarding information to backend systems
+    RequestHeader set "X-PROXY-UNIQUE-ID" "%{UNIQUE_ID}e"
+    RequestHeader set "X-PROXY-REMOTE-USER" "%{REMOTE_USER}e"
+    RequestHeader set "X-PROXY-SSL-PROTOCOL" "%{SSL_PROTOCOL}s"
+    RequestHeader set "X-PROXY-SSL-CIPHER" "%{SSL_CIPHER}s"
+
 </VirtualHost>
 
 <VirtualHost *:443>


### PR DESCRIPTION
The reverse proxy server shields the application server from direct client access. However, this also means that the application server is no longer able to see certain types of information about the client and its connection to the reverse proxy.

To compensate for this loss: 
- Activate the remoteip module to create an IP value similar to our reverse proxy in the backend server log file.
- Sets more HTTP request header lines to pass to the backend server.