### PR TITLE
Prevent unnecessary network requests with the HTTP Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ When it starts, Apache2.4 includes the module configuration files (/etc/apache2/
 - zzz-dir.conf: overrides the default serving directory index files configuration.
 - zzz-evasive.conf: overrides the default EVASIVE module configuration.
 - zzz-expires.conf: overrides and extends the default expirations time by type.
+- zzz-expires-cdn.conf: modern version for caching while using CDN.
+- zzz-expires-fingerprint.conf: modern version for caching while using fingerprinted URLs.
 - zzz-headers.conf: adds few HTTP request and response headers customizations.
 - zzz-log.conf: overrides log configuration.
 - zzz-mime.conf: adds more mime types.
@@ -62,6 +64,8 @@ Module mod_http2 must be enable to provides HTTP/2 support in SSL.
 ### Features
 
 - _common.conf: contains many files with common snippets.
+  - **access_control directory** contains Access control directives for application and static website.
+  - **security directory** contains security directives for HSTS and WordPress.
 - 000-default: contains the default virtualhost configuration.
 - static.tld: contains the name-based vhost configuration for a static website.
 - app.tld: contains the name-based vhost configuration for a PHP application.

--- a/src/conf-available/zzz-expires-cdn.conf
+++ b/src/conf-available/zzz-expires-cdn.conf
@@ -1,0 +1,35 @@
+## -----------------------------------------------------
+## Apache 2.4
+## User expires configuration file when using a CDN
+## !!! Do not load in reverse proxy case !!!
+## !!! Do not load zzz-expires.conf !!!
+## !!! Do not load zzz-expires-fingerprint.conf !!!
+##
+## @context server config
+## @module expires_module
+## @author Olivier Jullien <https://github.com/ojullien>
+## -----------------------------------------------------
+
+# A modern default for caching is to actually do no caching at all, and use CDNs to bring your content close to your users.
+# Every time a user loads your site, they'll go to the network to see whether it's up-to-date.
+# This request will have low latency, as it'll be provided by a CDN geographically close to each end user.
+#  Cache-Control: no-cache for resources that should be revalidated with the server before every use.
+#  Cache-Control: no-store for resources that should never be cached.
+#  Cache-Control: max-age=31536000 for versioned resources.
+
+<IfModule expires_module>
+  # Disable expirations
+  ExpiresActive Off
+</IfModule>
+
+<IfModule headers_module>
+  Header append Cache-Control "no-cache"
+</IfModule>
+
+# No ETag
+
+FileEtag none
+
+<IfModule headers_module>
+  Header unset ETag
+</IfModule>

--- a/src/conf-available/zzz-expires-fingerprint.conf
+++ b/src/conf-available/zzz-expires-fingerprint.conf
@@ -1,0 +1,40 @@
+## -----------------------------------------------------
+## Apache 2.4
+## Load this file if you use fingerprinted URLs
+## !!! Do not load in reverse proxy case !!!
+## !!! Do not load zzz-expires.conf !!!
+## !!! Do not load zzz-expires-cdn.conf !!!
+##
+## @context server config
+## @module expires_module
+## @author Olivier Jullien <https://github.com/ojullien>
+## -----------------------------------------------------
+
+# By including a hash of the file's content in the name of assets, images, and so on served on your site,
+# you can ensure that these files will always have unique content.
+#  Cache-Control: no-cache for resources that should be revalidated with the server before every use.
+#  Cache-Control: no-store for resources that should never be cached.
+#  Cache-Control: max-age=31536000 for versioned resources.
+
+<IfModule expires_module>
+  # Disable expirations
+  ExpiresActive Off
+</IfModule>
+
+<IfModule headers_module>
+  # No cache in CDN if any
+  Header append Cache-Control "max-age=0,private,must-revalidate"
+  # Static files
+  <FilesMatch "\.(tiff|webp|bmp|css|eot|flv|gif|ic[os]|jpe?g|m?js|m4[av]|manifest|mp4|og[agv]|otf|pdf|png|rss|svgz?|swf|tt[cf]|txt|vcard|vcf|webapp|web[mp]|webmanifest|woff2?|xml)$">
+    Header set Cache-Control "public,max-age=31536000,immutable"
+ </filesMatch>
+</IfModule>
+
+# ETag
+
+FileEtag MTime Size
+
+# Uncomment to disable ETag
+#<IfModule headers_module>
+#    Header unset ETag
+#</IfModule>

--- a/src/conf-available/zzz-expires.conf
+++ b/src/conf-available/zzz-expires.conf
@@ -1,7 +1,9 @@
 ## -----------------------------------------------------
 ## Apache 2.4
 ## User expires configuration file.
-## Do not load in reverse proxy case !!!
+## !!! Do not load in reverse proxy case !!!
+## !!! Do not load zzz-expires-cdn.conf !!!
+## !!! Do not load zzz-expires-fingerprint.conf !!!
 ##
 ## @context server config
 ## @module expires_module
@@ -25,7 +27,7 @@
  ExpiresByType application/pdf A2629800
  ExpiresByType application/xhtml+xml A10800
  ExpiresByType application/x-shockwave-flash A2629800
- ExpiresByType application/json A10800
+ ExpiresByType application/json A60
  ExpiresByType application/ld+json A10800
  ExpiresByType application/manifest+json A10800
  ExpiresByType application/xml A10800
@@ -57,7 +59,7 @@
  ExpiresByType text/cache-manifest A604800
  ExpiresByType text/css A2629800
  ExpiresByType text/csv A2629800
- ExpiresByType text/html A10800
+ ExpiresByType text/html A60
  ExpiresByType text/javascript A604800
  ExpiresByType text/plain A604800
  ExpiresByType text/xml A10800
@@ -75,12 +77,16 @@
 
 <IfModule headers_module>
     Header append Cache-Control "public"
+    # The expires header is legacy and is overruled by cache-control
+    Header unset Expires
 </IfModule>
 
-#No ETag
+# ETag
 
-<IfModule headers_module>
-    Header unset ETag
-</IfModule>
+FileEtag MTime Size
 
-FileEtag none
+# Uncomment to disable ETag
+#<IfModule headers_module>
+#    Header unset ETag
+#</IfModule>
+


### PR DESCRIPTION
It is important to specify one of Expires or Cache-Control max-age, and one of Last-Modified or ETag, for all cacheable resources. 

It is redundant to specify both Expires and Cache-Control: max-age, or to specify both Last-Modified and ETag.

Fixes #17 and #18