### PR TITLE
The 'X-Frame-Options' header should not be used anymore

### DIFF
--- a/src/conf-available/zzz-headers.conf
+++ b/src/conf-available/zzz-headers.conf
@@ -1,7 +1,7 @@
 ## -----------------------------------------------------
 ## Apache 2.4
 ## User headers configuration file.
-## Do not load in reverse proxy case !!!
+## !!! Do not load in reverse proxy case !!!
 ##
 ## @context server config
 ## @module headers_module
@@ -23,24 +23,6 @@
 #
 <IfModule headers_module>
     Header always set X-Content-Type-Options: "nosniff"
-</IfModule>
-
-#
-# Setting this header will prevent other sites from embedding pages from this
-# site as frames. This defends against clickjacking attacks.
-# Requires mod_headers to be enabled.
-#
-<IfModule headers_module>
-
-    Header always set X-Frame-Options DENY
-
-    # `mod_headers` cannot match based on the content-type, however,
-    # the `X-Frame-Options` response header should be sent only for
-    # HTML documents and not for the other resources.
-    #<FilesMatch "\.(bmp|css|eot|flv|gif|gz|ic[os]|jpe?g|m?js|json(ld)?|m4[av]|manifest|mp4|og[agv]|otf|pdf|png|rss|svgz?|swf|tt[cf]|txt|vcard|vcf|webapp|web[mp]|webmanifest|woff2?|xml)$">
-    #     Header unset X-Frame-Options
-    #</FilesMatch>
-
 </IfModule>
 
 #

--- a/src/sites-available/000-default/include/csp.conf
+++ b/src/sites-available/000-default/include/csp.conf
@@ -15,7 +15,7 @@
     # browser to load allowed content to load on the website.
     # Requires mod_headers to be enabled.
     #
-    Header always set Content-Security-Policy "default-src 'none'; img-src 'self';"
+    Header always set Content-Security-Policy "default-src 'none'; img-src 'self';frame-ancestors 'none';"
 </IfModule>
 
 ## -----------------------------------------------------

--- a/src/sites-available/api.tld/include/app01/csp.conf
+++ b/src/sites-available/api.tld/include/app01/csp.conf
@@ -15,7 +15,7 @@
     # origins and script endpoints. This helps guard against cross-site scripting attacks (XSS).
     # Requires mod_headers to be enabled.
     #
-    Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';"
+    Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';frame-ancestors 'self';"
 </IfModule>
 
 ## -----------------------------------------------------

--- a/src/sites-available/api.tld/include/app02/csp.conf
+++ b/src/sites-available/api.tld/include/app02/csp.conf
@@ -15,7 +15,7 @@
     # origins and script endpoints. This helps guard against cross-site scripting attacks (XSS).
     # Requires mod_headers to be enabled.
     #
-    Header always set Content-Security-Policy "default-src 'none'; frame-ancestors 'none';"
+    Header always set Content-Security-Policy "default-src 'none'; frame-ancestors 'none';frame-ancestors 'none';"
 </IfModule>
 
 ## -----------------------------------------------------

--- a/src/sites-available/static.tld/include/csp.conf
+++ b/src/sites-available/static.tld/include/csp.conf
@@ -15,7 +15,7 @@
     # origins and script endpoints. This helps guard against cross-site scripting attacks (XSS).
     # Requires mod_headers to be enabled.
     #
-    Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';"
+    Header always set Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';frame-ancestors 'self';"
 </IfModule>
 
 ## -----------------------------------------------------


### PR DESCRIPTION
A similar effect, with more consistent support and stronger checks, can be achieved with the 'Content-Security-Policy' header and 'frame-ancestors' directive. 

Read this [MDN's article](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors)

Fixes #19 