### PR TITLE
Add config variable for HSTS tuning

### DIFF
--- a/src/sites-available/_common.conf/security/hsts_with_preload.conf
+++ b/src/sites-available/_common.conf/security/hsts_with_preload.conf
@@ -9,7 +9,11 @@
 
 <IfModule ssl_module>
     <IfModule headers_module>
-        Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        <IfDefine !USER_MAX_AGE>
+            Define USER_MAX_AGE 31536000
+        </IfDefine>
+        Header always set Strict-Transport-Security "max-age=${USER_MAX_AGE}; includeSubDomains; preload"
+        UnDefine USER_MAX_AGE
     </IfModule>
 </IfModule>
 

--- a/src/sites-available/_common.conf/security/hsts_without_preload.conf
+++ b/src/sites-available/_common.conf/security/hsts_without_preload.conf
@@ -9,7 +9,11 @@
 
 <IfModule ssl_module>
     <IfModule headers_module>
-        Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        <IfDefine !USER_MAX_AGE>
+            Define USER_MAX_AGE 31536000
+        </IfDefine>
+        Header always set Strict-Transport-Security "max-age=${USER_MAX_AGE}; includeSubDomains"
+        UnDefine USER_MAX_AGE
     </IfModule>
 </IfModule>
 


### PR DESCRIPTION
Add the USER_MAX_AGE config variable for HSTS tuning directive.

The USER_MAX_AGE variable is used in [hsts_with_preload.conf](/ojullien/Apache2.4/blob/main/src/sites-available/_common.conf/security/hsts_with_preload.conf) and [hsts_without_preload.conf](/ojullien/Apache2.4/blob/main/src/sites-available/_common.conf/security/hsts_without_preload.conf) 

The USER_MAX_AGE variable may be defined in the ssl config file like [this one](/ojullien/Apache2.4/blob/main/src/sites-available/static.tld/include/ssl.conf) before the directive: `Include sites-available/_common.conf/security/hsts_without_preload.conf`