### PR TITLE
Remove unneeded HTTP X-XSS-Protection Header

### DIFF
--- a/src/conf-available/zzz-headers.conf
+++ b/src/conf-available/zzz-headers.conf
@@ -39,4 +39,8 @@
     # "1;mode=block" means XSS filter enabled and prevented rendering the page if attack detected
     # "1;report=http://example.com/report_URI" means XSS filter enabled and reported the violation if attack detected
     Header always set X-XSS-Protection "1; mode=block"
+    # Remove this header for static files
+    <FilesMatch "\.(appcache|atom|bbaw|bmp|crx|css|cur|eot|f4[abpv]|flv|geojson|gif|htc|ic[os]|jpe?g|m?js|json(ld)?|m4[av]|manifest|map|markdown|md|mp4|oex|og[agv]|opus|otf|pdf|png|rdf|rss|safariextz|svgz?|swf|topojson|tt[cf]|txt|vcard|vcf|vtt|webapp|web[mp]|webmanifest|woff2?|xloc|xpi)$">
+        Header unset X-XSS-Protection
+    </FilesMatch>
 </IfModule>

--- a/src/sites-available/api.tld/include/app02/csp.conf
+++ b/src/sites-available/api.tld/include/app02/csp.conf
@@ -15,7 +15,7 @@
     # origins and script endpoints. This helps guard against cross-site scripting attacks (XSS).
     # Requires mod_headers to be enabled.
     #
-    Header always set Content-Security-Policy "default-src 'none'; frame-ancestors 'none';frame-ancestors 'none';"
+    Header always set Content-Security-Policy "default-src 'none'; frame-ancestors 'none';"
 </IfModule>
 
 ## -----------------------------------------------------

--- a/src/sites-available/app.tld/include/csp.conf
+++ b/src/sites-available/app.tld/include/csp.conf
@@ -15,7 +15,7 @@
     # origins and script endpoints. This helps guard against cross-site scripting attacks (XSS).
     # Requires mod_headers to be enabled.
     #
-    Header always set Content-Security-Policy-Report-Only "default-src 'self';"
+    Header always set Content-Security-Policy-Report-Only "default-src 'self'; frame-ancestors 'none';"
     #Header always set Content-Security-Policy "default-src 'self';"
 </IfModule>
 


### PR DESCRIPTION
Even if we implement Content-Security-Policy and we do not need to support legacy browsers, we still keep this directive. Just for non-static files only.

Closes #25.