### PR TITLE
Add the Referrer-Policy HTTP header

### DIFF
--- a/src/conf-available/zzz-headers.conf
+++ b/src/conf-available/zzz-headers.conf
@@ -47,4 +47,12 @@
     <FilesMatch "\.(appcache|atom|bbaw|bmp|crx|css|cur|eot|f4[abpv]|flv|geojson|gif|htc|ic[os]|jpe?g|json(ld)?|m4[av]|manifest|map|markdown|md|mp4|oex|og[agv]|opus|otf|png|rdf|rss|safariextz|swf|topojson|tt[cf]|txt|vcard|vcf|vtt|webapp|web[mp]|webmanifest|woff2?|xloc|xpi)$">
         Header unset Content-Security-Policy
     </FilesMatch>
+    #
+    # The Referrer-Policy HTTP header controls how much referrer information (sent via the Referer header) should be
+    # included with requests.
+    # Setting an HTTP referer policy is for security. If these headers are being generated on the server and not
+    # controlled properly, sensitive meta-information about the incoming request can get passed from an HTTPS endpoint
+    # to a non-secure, HTTP one, nullifying the benefits of adding HTTPS encryption to your website.
+    #
+    Header always set Referrer-Policy "no-referrer-when-downgrade, strict-origin-when-cross-origin"
 </IfModule>


### PR DESCRIPTION
The Referrer policy is used by the server to define its behavior of setting the HTTP Referer headers.

The greater need for setting an HTTP referer policy is for security. If these headers are being generated on the server and not controlled properly, sensitive meta-information about the incoming request can get passed from an HTTPS endpoint to a non-secure, HTTP one, nullifying the benefits of adding HTTPS encryption to your website.

Fixes #23 